### PR TITLE
Fix #45 devices can monitor an accessor

### DIFF
--- a/slicops/device.py
+++ b/slicops/device.py
@@ -142,7 +142,7 @@ class _Accessor:
                 raise ValueError(f"already monitoring {self}")
             # should lock
             self._callback_index = self._pv.add_callback(self._on_value)
-            a._pv.auto_monitor = True
+            self._pv.auto_monitor = True
             self._callback = callback
 
     def monitor_stop(self):

--- a/slicops/device.py
+++ b/slicops/device.py
@@ -171,13 +171,12 @@ class _Accessor:
 
     def _fixup_value(self, raw):
         def _reshape(image):
-            # TODO(robnagler) does get return 0 ever?
             if not (
                 (r := self.device.get("num_rows"))
                 and (c := self.device.get("num_cols"))
             ):
                 raise ValueError("num_rows or num_cols is invalid")
-            return image.reshape(c, r)
+            return image.reshape((r, c) if self.meta.array_is_row_major else (c, r))
 
         if self.meta.py_type == "bool":
             return bool(raw)
@@ -191,7 +190,7 @@ class _Accessor:
             pkdlog("missing 'conn' in kwargs={}", kwargs)
             self._run_callback(error="missing conn")
         else:
-            self._run_callback(connected=conn)
+            self._run_callback(connected=kwargs["conn"])
 
     def _on_value(self, **kwargs):
         if (v := kwargs.get("value")) is None:

--- a/slicops/device_meta_raw.py
+++ b/slicops/device_meta_raw.py
@@ -3,7 +3,7 @@
 **DO NOT EDIT; automatically generated**
 
 * generator: slicops.pkcli.device_yaml
-* input: /home/vagrant/src/slaclab/lcls-tools/lcls_tools/common/devices/yaml/*.yaml
+* input: /home/vagrant/.pyenv/versions/3.9.15/envs/py3/lib/python3.9/site-packages/lcls_tools/common/devices/yaml/*.yaml
 
 :copyright: Copyright (c) 2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All Rights Reserved.
 :license: http://github.com/slaclab/slicops/LICENSE
@@ -493,6 +493,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:UNDS:3575:IMAGE",
@@ -507,9 +508,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:UNDS:3575:N_OF_ROW",
                                         "py_type": "int",
@@ -555,6 +556,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:UNDS:3795:IMAGE",
@@ -569,9 +571,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:UNDS:3795:N_OF_ROW",
                                         "py_type": "int",
@@ -626,6 +628,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": True,
                                         "name": "image",
                                         "pv_base": "image1:ArrayData",
                                         "pv_name": "13SIM1:image1:ArrayData",
@@ -635,16 +638,16 @@ DB = PKDict(
                                 "num_cols": PKDict(
                                     {
                                         "name": "num_cols",
-                                        "pv_base": "cam1:ArraySizeY_RBV",
-                                        "pv_name": "13SIM1:cam1:ArraySizeY_RBV",
+                                        "pv_base": "cam1:ArraySizeX_RBV",
+                                        "pv_name": "13SIM1:cam1:ArraySizeX_RBV",
                                         "py_type": "int",
                                     }
                                 ),
                                 "num_rows": PKDict(
                                     {
                                         "name": "num_rows",
-                                        "pv_base": "cam1:ArraySizeX_RBV",
-                                        "pv_name": "13SIM1:cam1:ArraySizeX_RBV",
+                                        "pv_base": "cam1:ArraySizeY_RBV",
+                                        "pv_name": "13SIM1:cam1:ArraySizeY_RBV",
                                         "py_type": "int",
                                     }
                                 ),
@@ -681,6 +684,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:HTR:330:Image:ArrayData",
@@ -746,6 +750,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "OTRS:LI21:237:IMAGE",
@@ -760,9 +765,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "OTRS:LI21:237:N_OF_ROW",
                                         "py_type": "int",
@@ -808,6 +813,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:BC1B:470:Image:ArrayData",
@@ -872,6 +878,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "OTRS:LI21:291:IMAGE",
@@ -886,9 +893,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "OTRS:LI21:291:N_OF_ROW",
                                         "py_type": "int",
@@ -934,6 +941,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:IN20:571:Image:ArrayData",
@@ -997,6 +1005,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "OTRS:LI24:807:IMAGE",
@@ -1011,9 +1020,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "OTRS:LI24:807:N_OF_ROW",
                                         "py_type": "int",
@@ -1059,6 +1068,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:BC2B:545:Image:ArrayData",
@@ -1123,6 +1133,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "OTRS:IN20:621:IMAGE",
@@ -1137,9 +1148,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "OTRS:IN20:621:N_OF_ROW",
                                         "py_type": "int",
@@ -1186,6 +1197,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "OTRS:IN20:711:IMAGE",
@@ -1200,9 +1212,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "OTRS:IN20:711:N_OF_ROW",
                                         "py_type": "int",
@@ -1248,6 +1260,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:COL0:535:Image:ArrayData",
@@ -1312,6 +1325,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:DIAG0:420:Image:ArrayData",
@@ -1367,6 +1381,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:DIAG0:525:Image:ArrayData",
@@ -1422,6 +1437,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:DMPH:695:Image:ArrayData",
@@ -1477,6 +1493,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:DMPS:695:Image:ArrayData",
@@ -1532,6 +1549,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:DOG:195:Image:ArrayData",
@@ -1596,6 +1614,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:IN20:465:Image:ArrayData",
@@ -1659,6 +1678,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "OTRS:IN20:471:Image:ArrayData",
@@ -1722,6 +1742,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:DASEL:440:Image:ArrayData",
@@ -1777,6 +1798,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:DASEL:655:Image:ArrayData",
@@ -1832,6 +1854,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "PROF:DASEL:818:Image:ArrayData",
@@ -1887,6 +1910,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "CAMR:IN20:186:IMAGE",
@@ -1901,9 +1925,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "CAMR:IN20:186:N_OF_ROW",
                                         "py_type": "int",
@@ -1942,6 +1966,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "CAMR:LGUN:950:Image:ArrayData",
@@ -1951,16 +1976,16 @@ DB = PKDict(
                                 "num_cols": PKDict(
                                     {
                                         "name": "num_cols",
-                                        "pv_base": "Image:ArraySizeY_RBV",
-                                        "pv_name": "CAMR:LGUN:950:Image:ArraySizeY_RBV",
+                                        "pv_base": "Image:ArraySizeX_RBV",
+                                        "pv_name": "CAMR:LGUN:950:Image:ArraySizeX_RBV",
                                         "py_type": "int",
                                     }
                                 ),
                                 "num_rows": PKDict(
                                     {
                                         "name": "num_rows",
-                                        "pv_base": "Image:ArraySizeX_RBV",
-                                        "pv_name": "CAMR:LGUN:950:Image:ArraySizeX_RBV",
+                                        "pv_base": "Image:ArraySizeY_RBV",
+                                        "pv_name": "CAMR:LGUN:950:Image:ArraySizeY_RBV",
                                         "py_type": "int",
                                     }
                                 ),
@@ -1997,6 +2022,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:IN20:211:IMAGE",
@@ -2011,9 +2037,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:IN20:211:N_OF_ROW",
                                         "py_type": "int",
@@ -2061,6 +2087,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "YAGS:IN20:241:Image:ArrayData",
@@ -2124,6 +2151,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:IN20:351:IMAGE",
@@ -2138,9 +2166,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:IN20:351:N_OF_ROW",
                                         "py_type": "int",
@@ -2187,6 +2215,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:IN20:841:IMAGE",
@@ -2201,9 +2230,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:IN20:841:N_OF_ROW",
                                         "py_type": "int",
@@ -2242,6 +2271,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "YAGS:HTR:625:Image:ArrayData",
@@ -2307,6 +2337,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "YAGS:HTR:675:Image:ArrayData",
@@ -2372,6 +2403,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "Image:ArrayData",
                                         "pv_name": "YAGS:LTUH:743:Image:ArrayData",
@@ -2433,6 +2465,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:IN20:921:IMAGE",
@@ -2447,9 +2480,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:IN20:921:N_OF_ROW",
                                         "py_type": "int",
@@ -2488,6 +2521,7 @@ DB = PKDict(
                                 ),
                                 "image": PKDict(
                                     {
+                                        "array_is_row_major": False,
                                         "name": "image",
                                         "pv_base": "IMAGE",
                                         "pv_name": "YAGS:IN20:995:IMAGE",
@@ -2502,9 +2536,9 @@ DB = PKDict(
                                         "py_type": "int",
                                     }
                                 ),
-                                "num_rols": PKDict(
+                                "num_rows": PKDict(
                                     {
-                                        "name": "num_rols",
+                                        "name": "num_rows",
                                         "pv_base": "N_OF_ROW",
                                         "pv_name": "YAGS:IN20:995:N_OF_ROW",
                                         "py_type": "int",

--- a/slicops/mock_epics.py
+++ b/slicops/mock_epics.py
@@ -1,4 +1,4 @@
-"""mock epics.PV for slicops
+"""Emulate epics.PV for unit tests
 
 :copyright: Copyright (c) 2025 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All Rights Reserved.
 :license: http://github.com/slaclab/slicops/LICENSE
@@ -6,39 +6,20 @@
 
 from pykern.pkcollections import PKDict
 from pykern.pkdebug import pkdc, pkdlog, pkdp
+import copy
 import numpy
 import sys
 import threading
+import time
 
-_SIZE = 50
-_SIGMA = _SIZE // 5
+MONITOR_X_SIZE = [50, 100, 150, 200]
+
+MONITOR_SLEEP = .1
+
+_X_SIZE = 50
 _Y_FACTOR = 1.3
 
-def _y_adjust(value):
-    return int(value * _Y_FACTOR)
-
-def _gaussian(size, sigma, y_factor):
-
-    def _dist(vec, sigma_factor):
-        return (vec - vec.shape[0] // 2) ** 2 / (2 * (_y_adjust(sigma) ** 2))
-
-    def _vec(size):
-        return numpy.linspace(0, size - 1, size)
-
-    x, y = numpy.meshgrid(_vec(size), _vec(_y_adjust(size)))
-    return numpy.exp(-(_dist(x, 1) + _dist(y, y_factor)))
-
-
-_pv_values = PKDict(
-    {
-        "13SIM1:cam1:Gain": 93,
-        "13SIM1:image1:ArrayData": _gaussian(_SIZE, _SIGMA, _Y_FACTOR),
-        "13SIM1:cam1:Acquire": 0,
-        "13SIM1:cam1:ArraySizeX_RBV": _SIZE,
-        "13SIM1:cam1:ArraySizeY_RBV": _y_adjust(_SIZE),
-        "13SIM1:cam1:N_OF_BITS": 8,
-    }
-)
+_PV = None
 
 
 class PV:
@@ -66,14 +47,23 @@ class PV:
 
     @auto_monitor.setter
     def auto_monitor(self, value):
+        def _image():
+            for s in MONITOR_X_SIZE:
+                time.sleep(MONITOR_SLEEP)
+                _PV.pkupdate(_pv_image(s))
+                self.monitor_callback(value=_PV[self.pvname])
+
         self._auto_monitor = value
+        if value:
+            t = threading.Thread(target=_image)
+            t.start()
 
     def get(self):
         # TOOD(robnagler) need to be more sophisticated
-        return _pv_values.get(self.pvname, None)
+        return _PV.get(self.pvname, None)
 
     def put(self, value):
-        _pv_values[self.pvname] = value
+        _PV[self.pvname] = value
         return 1
 
     def remove_callback(self, index):
@@ -81,6 +71,46 @@ class PV:
             raise AssertionError(f"invalid index={index}")
         self.monitor_callback = None
 
+
+def reset_state():
+    global _PV
+
+    _PV = PKDict(
+        {
+            "13SIM1:cam1:Gain": 93,
+            "13SIM1:cam1:Acquire": 0,
+            "13SIM1:cam1:N_OF_BITS": 8,
+        }
+    ).pkupdate(_pv_image(_X_SIZE))
+
+
+def _gaussian(x_size):
+    sigma = x_size // 5
+
+    def _dist(vec, is_y):
+        s = _y_adjust(sigma) if is_y else sigma
+        return (vec - vec.shape[0] // 2) ** 2 / (2 * (s**2))
+
+    def _norm(mat):
+        return ((mat - mat.min()) / (mat.max() - mat.min())) * 255
+
+    def _vec(size):
+        return numpy.linspace(0, size - 1, size)
+
+    x, y = numpy.meshgrid(_vec(x_size), _vec(_y_adjust(x_size)))
+    return _norm(numpy.exp(-(_dist(x, False) + _dist(y, True))))
+
+
+def _pv_image(size):
+    return {
+        "13SIM1:cam1:ArraySizeX_RBV": size,
+        "13SIM1:cam1:ArraySizeY_RBV": _y_adjust(size),
+        "13SIM1:image1:ArrayData": _gaussian(size),
+    }
+
+
+def _y_adjust(value):
+    return int(value * _Y_FACTOR)
 
 
 if "epics" in sys.modules:

--- a/slicops/mock_epics.py
+++ b/slicops/mock_epics.py
@@ -47,15 +47,17 @@ class PV:
 
     @auto_monitor.setter
     def auto_monitor(self, value):
-        def _image():
+        def _update():
+            self.connection_callback(conn=True)
             for s in MONITOR_X_SIZE:
                 time.sleep(MONITOR_SLEEP)
                 _PV.pkupdate(_pv_image(s))
                 self.monitor_callback(value=_PV[self.pvname])
+            self.connection_callback(conn=False)
 
         self._auto_monitor = value
         if value:
-            t = threading.Thread(target=_image)
+            t = threading.Thread(target=_update)
             t.start()
 
     def get(self):

--- a/slicops/mock_epics.py
+++ b/slicops/mock_epics.py
@@ -72,14 +72,15 @@ class PV:
         # TOOD(robnagler) need to be more sophisticated
         return _pv_values.get(self.pvname, None)
 
+    def put(self, value):
+        _pv_values[self.pvname] = value
+        return 1
+
     def remove_callback(self, index):
         if index != self._CB_INDEX:
             raise AssertionError(f"invalid index={index}")
         self.monitor_callback = None
 
-    def put(self, value):
-        _pv_values[self.pvname] = value
-        return 1
 
 
 if "epics" in sys.modules:

--- a/slicops/mock_epics.py
+++ b/slicops/mock_epics.py
@@ -105,7 +105,8 @@ def _pv_image(size):
     return {
         "13SIM1:cam1:ArraySizeX_RBV": size,
         "13SIM1:cam1:ArraySizeY_RBV": _y_adjust(size),
-        "13SIM1:image1:ArrayData": _gaussian(size),
+        # numpy is row major ("C" style)
+        "13SIM1:image1:ArrayData": _gaussian(size).flatten(),
     }
 
 

--- a/slicops/mock_epics.py
+++ b/slicops/mock_epics.py
@@ -14,7 +14,7 @@ import time
 
 MONITOR_X_SIZE = [50, 100, 150, 200]
 
-MONITOR_SLEEP = .1
+MONITOR_SLEEP = 0.1
 
 _X_SIZE = 50
 _Y_FACTOR = 1.3

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -31,6 +31,8 @@ def test_monitor():
     x_size = list(reversed(mock_epics.MONITOR_X_SIZE))
     count = len(x_size)
 
+    # TODO teset test conn
+
     def _monitor(update):
         nonlocal x_size, count
 

--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -1,0 +1,46 @@
+"""Test slicops.device
+
+:copyright: Copyright (c) 2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All Rights Reserved.
+:license: http://github.com/slaclab/slicops/LICENSE
+"""
+
+
+def test_basic():
+    # Must be first
+    from slicops import mock_epics
+    from pykern import pkdebug, pkunit
+    from slicops import device
+
+    mock_epics.reset_state()
+    d = device.Device("DEV_CAMERA")
+    # Reshape switches x & y
+    pkunit.pkeq((65, 50), d.get("image").shape)
+    pkunit.pkeq(False, d.get("acquire"))
+    d.put("acquire", True)
+    pkunit.pkeq(True, d.get("acquire"))
+
+
+def test_monitor():
+    # Must be first
+    from slicops import mock_epics
+    from pykern import pkdebug, pkunit
+    from slicops import device
+    import time
+
+    mock_epics.reset_state()
+    x_size = list(reversed(mock_epics.MONITOR_X_SIZE))
+    count = len(x_size)
+
+    def _monitor(update):
+        nonlocal x_size, count
+
+        # reshape will switch x & y
+        pkunit.pkeq(x_size.pop(), update.value.shape[1])
+        count -= 1
+
+    a = device.Device("DEV_CAMERA").accessor("image")
+    a.monitor(_monitor)
+    time.sleep(count * 2 * mock_epics.MONITOR_SLEEP)
+    if count != 0:
+        # mock_epics issues 4 updates
+        pkunit.pkfail("image sizes didn't match count={}", count)

--- a/tests/ui_api_test.py
+++ b/tests/ui_api_test.py
@@ -63,6 +63,7 @@ def _setup():
 
         def _server_config(self, *args, **kwargs):
             from slicops import mock_epics
+            mock_epics.reset_state()
 
             return super()._server_config(*args, **kwargs)
 

--- a/tests/ui_api_test.py
+++ b/tests/ui_api_test.py
@@ -29,8 +29,8 @@ async def test_basic():
         pkunit.pkeq(93, ux.camera_gain.value)
         r = await c.call_api("screen_start_button", PKDict(field_value=False))
         ux = r.ui_ctx
-        pkunit.pkeq(100, len(r.plot.raw_pixels))
-        pkunit.pkeq(100, len(r.plot.raw_pixels[0]))
+        pkunit.pkeq(65, len(r.plot.raw_pixels))
+        pkunit.pkeq(50, len(r.plot.raw_pixels[0]))
         r = await c.call_api("screen_stop_button", PKDict(field_value=False))
         ux = r.ui_ctx
         ux = await _put(ux, "camera_gain", "33", 33)

--- a/tests/ui_api_test.py
+++ b/tests/ui_api_test.py
@@ -31,6 +31,9 @@ async def test_basic():
         ux = r.ui_ctx
         pkunit.pkeq(65, len(r.plot.raw_pixels))
         pkunit.pkeq(50, len(r.plot.raw_pixels[0]))
+        # x fit should be 10
+        pkunit.pkeq(10.00, round(r.plot.x.fit.results.sig, 2))
+        pkunit.pkeq(13.00, round(r.plot.y.fit.results.sig, 2))
         r = await c.call_api("screen_stop_button", PKDict(field_value=False))
         ux = r.ui_ctx
         ux = await _put(ux, "camera_gain", "33", 33)
@@ -63,6 +66,7 @@ def _setup():
 
         def _server_config(self, *args, **kwargs):
             from slicops import mock_epics
+
             mock_epics.reset_state()
 
             return super()._server_config(*args, **kwargs)

--- a/tests/ui_api_test.py
+++ b/tests/ui_api_test.py
@@ -7,7 +7,7 @@
 import pytest
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_basic():
 
     async def _put(ux, field, new, expect):


### PR DESCRIPTION
- Fix #44 added array_is_row_major to know how to reshape (most devices are column major)
- Fix #23 mock_epics generates an asymmetric gaussian so fit can be checked
- Fix #24 generates a series of images for monitoring
- factored out device._Accessor for better modularization
- Fixed num_rows & num_cols flip in device_yaml