### PR TITLE
Fix #47: create infrastructure and documentation for building SlicOps podman image

### DIFF
--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -25,12 +25,11 @@ export EPICS_BASE=$HOME/.local/epics
 # $EPICS_BASE/startup/EpicsHostArch outputs linux-x86_64; no need to be dynamic here
 export EPICS_HOST_ARCH=linux-x86_64
 bivio_path_insert "$EPICS_BASE/bin/$EPICS_HOST_ARCH"
-export EPICS_PCAS_ROOT=$EPICS_BASE
 f=$EPICS_BASE/extensions/synApps/support/areaDetector-R3-12-1
 export EPICS_DISPLAY_PATH=.:$f/ADSimDetector/simDetectorApp/op/adl:$f/ADCore/ADApp/op/adl:$f/ADUVC/uvcApp/op/adl:$EPICS_BASE/modules/asyn/asyn-R4-45/opi/medm
 EOF
     install_not_strict_cmd source ~/.post_bivio_bashrc
-    bash epics-install.sh
+    source epics-install.sh
     cd ~/src/
     _slicops_pip_install radiasoft/pykern "$PYKERN_BRANCH"
     _slicops_pip_install slaclab/slicops "$SLICOPS_BRANCH"

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+build_vars() {
+    : ${build_image_base:=radiasoft/python3}
+    build_is_public=1
+    build_passenv='PYKERN_BRANCH SLICOPS_BRANCH'
+    : ${PYKERN_BRANCH:=} ${SLICOPS_BRANCH:=}
+}
+
+build_as_root() {
+    build_yum install \
+        libXt-devel \
+        libtirpc-devel \
+        motif-devel \
+        nodejs \
+        perl-ExtUtils-Command \
+        perl-FindBin \
+        rpcgen
+}
+
+build_as_run_user() {
+    install_source_bashrc
+    cat > ~/.post_bivio_bashrc <<'EOF'
+export EPICS_BASE=$HOME/.local/epics
+# $EPICS_BASE/startup/EpicsHostArch outputs linux-x86_64; no need to be dynamic here
+export EPICS_HOST_ARCH=linux-x86_64
+bivio_path_insert "$EPICS_BASE/bin/$EPICS_HOST_ARCH"
+export EPICS_PCAS_ROOT=$EPICS_BASE
+f=$EPICS_BASE/extensions/synApps/support/areaDetector-R3-12-1
+export EPICS_DISPLAY_PATH=.:$f/ADSimDetector/simDetectorApp/op/adl:$f/ADCore/ADApp/op/adl:$f/ADUVC/uvcApp/op/adl:$EPICS_BASE/modules/asyn/asyn-R4-45/opi/medm
+EOF
+    install_not_strict_cmd source ~/.post_bivio_bashrc
+    bash epics-install.sh
+    cd ~/src/
+    _slicops_pip_install radiasoft/pykern "$PYKERN_BRANCH"
+    _slicops_pip_install slaclab/slicops "$SLICOPS_BRANCH"
+    cd slaclab/slicops/ui
+    npm install
+}
+
+_slicops_pip_install() {
+    declare org_and_repo=$1
+    declare branch=$2
+    mkdir -p "$org_and_repo"
+    git clone -q -c advice.detachedHead=false ${branch:+--branch "$branch"} https://github.com/"$org_and_repo" "$org_and_repo"
+    cd "$org_and_repo"
+    pip install -e .
+    cd - &> /dev/null
+}
+
+build_vars

--- a/container-conf/build.sh
+++ b/container-conf/build.sh
@@ -36,6 +36,7 @@ EOF
     _slicops_pip_install slaclab/slicops "$SLICOPS_BRANCH"
     cd slaclab/slicops/ui
     npm install
+    npx ng build --output-path ../slicops/package_data/ng-build
 }
 
 _slicops_pip_install() {

--- a/container-conf/epics-install.sh
+++ b/container-conf/epics-install.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Install epics, asyn, medm, and synaps
+#
+set -eou pipefail
+shopt -s nullglob
+
+_asyn_version=R4-45
+_epics_version=7.0.8.1
+_medm_version=MEDM3_1_21
+_synapps_version=R6-3
+
+_curl_untar() {
+    declare url=$1
+    declare base=$2
+    declare tgt=$3
+    curl -L -s -S "$url" | tar xzf -
+    mv "$base" "$tgt"
+    cd "$tgt"
+}
+
+_build_base_and_asyn() {
+    sudo dnf -y install re2c
+    declare d=$(dirname "$EPICS_BASE")
+    mkdir -p "$d"
+    cd "$d"
+    b=base-"$_epics_version"
+    _curl_untar https://epics-controls.org/download/base/"$b".tar.gz "$b" "$EPICS_BASE"
+    cd "$EPICS_BASE"
+    cd modules
+    _curl_untar https://github.com/epics-modules/asyn/archive/refs/tags/"$_asyn_version".tar.gz "asyn-$_asyn_version" asyn
+    perl -pi -e 's/^# (?=TIRPC)//' configure/CONFIG_SITE
+    cd ..
+    echo 'SUBMODULES += asyn' > Makefile.local
+    cd ..
+    # parallel make does not work
+    make
+}
+
+_build_medm() {
+    _curl_untar https://github.com/epics-extensions/medm/archive/refs/tags/"$_medm_version".tar.gz "medm-$_medm_version" medm
+    perl -pi -e 's/^(?=USR_INCLUDES|SHARED_LIBRARIES|USR_LIBS)/#/' printUtils/Makefile
+    perl -pi -e 's/^(?=SHARED_LIBRARIES|USR_LIBS_DEFAULT)/#/; /USR_LIBS_DEFAULT/ && ($_ .= "USR_LDFLAGS_Linux = -lXm -lXt -lXmu -lXext -lX11\n")' xc/Makefile
+    perl -pi -e 's/^#(?=SCIPLOT)//; s/^(?=USR_LIBS)/#/; /USR_LIBS_DEFAULT/ && ($_ .= "USR_LDFLAGS_Linux = -lXm -lXt -lXp -lXmu -lXext -lX11\n")' medm/Makefile
+    grep USR_LDFLAGS_Linux medm/Makefile
+    grep USR_LDFLAGS_Linux xc/Makefile
+    # Not sure if parallel make works
+    make -j 4
+    cd - >& /dev/null
+}
+
+_build_synapps() {
+    declare d=synApps
+    # Must be absolute or fails silently
+    declare f=$PWD/$d.modules
+    cat <<'EOF' > "$f"
+AREA_DETECTOR=R3-12-1
+AUTOSAVE=R5-11
+BUSY=R1-7-4
+CALC=R3-7-5
+DEVIOCSTATS=3.1.16
+SNCSEQ=R2-2-9
+SSCAN=R2-11-6
+EOF
+    curl -s -S -L https://github.com/EPICS-synApps/assemble_synApps/releases/download/"$_synapps_version"/assemble_synApps \
+        | perl - --base="$EPICS_BASE" --dir="$d" --config="$f"
+    rm "$f"
+    cd "$d"/support
+    # otherwise gets a version conflict; This is the version that's installed already
+    # synApps does not install ASYN.
+    perl -pi -e 's/asyn-.*/asyn-4-42/' busy-R1-7-4/configure/RELEASE
+    make -j 4
+    cd - >& /dev/null
+}
+
+_err() {
+    _msg "$@"
+    return 1
+}
+
+_log() {
+    _msg $(date +%H%M%S) "$@"
+}
+
+_main() {
+    if [[ -d $EPICS_BASE ]]; then
+        _err "please remove:
+rm -rf '$EPICS_BASE'
+"
+    fi
+    _source_bashrc
+    bivio_path_remove "$EPICS_BASE"/bin
+    _build_base_and_asyn
+    # Add epics to the path
+    _source_bashrc
+    cd "$EPICS_BASE"
+    mkdir -p extensions
+    cd extensions
+    _build_medm
+    _build_synapps
+}
+
+_msg() {
+    echo "$*" 1>&2
+}
+
+_source_bashrc() {
+    set +eou pipefail
+    shopt -u nullglob
+    source $HOME/.bashrc
+    set -eou pipefail
+    shopt -s nullglob
+}
+
+_main "$@"

--- a/container-conf/epics-install.sh
+++ b/container-conf/epics-install.sh
@@ -60,42 +60,13 @@ EOF
     cd - >& /dev/null
 }
 
-_err() {
-    _msg "$@"
-    return 1
-}
-
-_log() {
-    _msg $(date +%H%M%S) "$@"
-}
-
 _main() {
-    if [[ -d $EPICS_BASE ]]; then
-        _err "please remove:
-rm -rf '$EPICS_BASE'
-"
-    fi
-    _source_bashrc
     bivio_path_remove "$EPICS_BASE"/bin
     _build_base_and_asyn
-    # Add epics to the path
-    _source_bashrc
     cd "$EPICS_BASE"
     mkdir -p extensions
     cd extensions
     _build_synapps
-}
-
-_msg() {
-    echo "$*" 1>&2
-}
-
-_source_bashrc() {
-    set +eou pipefail
-    shopt -u nullglob
-    source $HOME/.bashrc
-    set -eou pipefail
-    shopt -s nullglob
 }
 
 _main "$@"

--- a/container-conf/epics-install.sh
+++ b/container-conf/epics-install.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 #
-# Install epics, asyn, medm, and synaps
+# Install epics, asyn, and synaps
 #
 set -eou pipefail
 shopt -s nullglob
 
 _asyn_version=R4-45
 _epics_version=7.0.8.1
-_medm_version=MEDM3_1_21
 _synapps_version=R6-3
 
 _curl_untar() {
@@ -35,18 +34,6 @@ _build_base_and_asyn() {
     cd ..
     # parallel make does not work
     make
-}
-
-_build_medm() {
-    _curl_untar https://github.com/epics-extensions/medm/archive/refs/tags/"$_medm_version".tar.gz "medm-$_medm_version" medm
-    perl -pi -e 's/^(?=USR_INCLUDES|SHARED_LIBRARIES|USR_LIBS)/#/' printUtils/Makefile
-    perl -pi -e 's/^(?=SHARED_LIBRARIES|USR_LIBS_DEFAULT)/#/; /USR_LIBS_DEFAULT/ && ($_ .= "USR_LDFLAGS_Linux = -lXm -lXt -lXmu -lXext -lX11\n")' xc/Makefile
-    perl -pi -e 's/^#(?=SCIPLOT)//; s/^(?=USR_LIBS)/#/; /USR_LIBS_DEFAULT/ && ($_ .= "USR_LDFLAGS_Linux = -lXm -lXt -lXp -lXmu -lXext -lX11\n")' medm/Makefile
-    grep USR_LDFLAGS_Linux medm/Makefile
-    grep USR_LDFLAGS_Linux xc/Makefile
-    # Not sure if parallel make works
-    make -j 4
-    cd - >& /dev/null
 }
 
 _build_synapps() {
@@ -96,7 +83,6 @@ rm -rf '$EPICS_BASE'
     cd "$EPICS_BASE"
     mkdir -p extensions
     cd extensions
-    _build_medm
     _build_synapps
 }
 

--- a/podman.md
+++ b/podman.md
@@ -1,0 +1,123 @@
+# SlicOps and Podman
+
+SliCops is deployed in a Podman container image.
+
+## Building the image
+
+From the repository root run:
+
+```
+curl radia.run | container-build
+```
+
+That will start the process of building the image on your machine.
+
+If your curious about what those commands mean please read on. If you
+just want to build an image so you can run it then you can skip this
+information and jump to the next section.
+
+The command can be broken into two parts.
+
+First is `curl radia.run`. [Curl](https://curl.se/docs/manpage.html)
+is a tool for making http requests from a shell. `radia.run` is a
+website that RadiaSoft hosts which returns a shell script. You
+can try running `curl radia.run` yourself in your shell. You'll see
+the shell script printed out. The shell script that is downloaded
+allows one to run one of [RadiaSoft's
+"installers"](https://github.com/radiasoft/download). These are other
+shell scripts that do some action. In our case that action is
+`container-build`.
+
+Now we are at the second part of the command `container-build`. You
+can guess from the name of the command that it builds a container. In
+our case, it is going to build the slicops container. If you're
+curious about that command you can see what is run
+[here](https://github.com/radiasoft/download/blob/master/installers/container-build/radiasoft-download.sh).
+We'll breeze over the exact details and get to what is important, the
+`build.sh` file. `curl radia.run | container-build` ends up calling
+the `build.sh` file in the `container-conf` [directory of this
+repo](https://github.com/slaclab/slicops/blob/main/container-conf/build.sh).
+That file has three important functions.
+
+First, `build_vars`. This is the first function that is called in the
+script. It sets up variables that will be used in the script and by
+other code in `container-build`. The most important is
+`build_image_base`. This is set to `radiasoft/python3`. Podman images
+are built in "layers". What that means is an image can be built on top
+of another image. In our case we are building the SlicOps image on top
+of the `radiasoft/python3` image. The `radiasoft/python3` image is a
+Fedora image with some of the basic necessities (e.g. gcc) installed.
+Importantly for us, it has `python3` installed (SlicOps is a Python
+application).
+
+Next up is `build_as_root`. This function does all of its steps as the
+root user. For SlicOps that is installing packages like Node.JS and
+some of the EPICS dependencies.
+
+Finally, we have `build_as_run_user`. Similar to `build_as_root` this
+runs install steps. But, it runs them as the `run_user`. That is the
+user that will be running the application inside of the container. For
+SliCops this step installs EPICS and installs the SlicOps package.
+
+Once all of these steps are run then the image has all of the
+dependencies that are required to run SliCops.
+
+Running `container-build` will take many minutes.
+
+## Running the image
+
+Now we have built (or you got from someone / downloaded) the image and
+we are ready to run it.
+
+To run the image
+
+```
+podman run --rm --interactive --tty --network=host slaclab/slicops /bin/bash
+```
+
+Breaking down the parts of that command:
+- `podman`: Call the podman program
+- `run`: The command we want. In this case, to run the image.
+- `--rm`: Automatically remove the container when it exits. If we
+  don't have this flag the container will be left "paused" when you
+  exit. These paused containers tend to accumulate and just take up
+  space on your machine.
+- `--interactive`: Keep STDIN open. This will allow us to enter
+  commands inside of the running container.
+- `--tt`: Allocate a "pseudo-teletypewriter". Basically, make working
+  inside of the container in a shell work like how a using a terminal
+  works on your computer.
+- `--network=host`: Use the host machines network stack. This means
+  that any http server started in the container will appear as if it
+  was started on your computer. You'll be able to connect to it over
+  localhost.
+- `slaclab/slicops`: This is the name of the image we want to run.
+- `/bin/bash`: Run the bash shell when the container is started
+
+Once the container is started you will be dropped into a bash shell.
+From there you can start the necessary software.
+
+First, start the EPICS sim detector which is a simulated detector that the rest of the application
+will use to read images from.
+```
+slicops epics sim-detector
+```
+
+Next, start the "ui-api". This is the Python web server that
+interfaces between EPICS and the GUI to read from PV's and send the
+outputs to the browser.
+
+```
+slicops service ui-api
+```
+
+Next, start the GUI. This is an Angular application that we access in
+our web browser
+
+```
+cd ~/src/slaclab/slicops/ui/
+npx ng serve --port 8080
+```
+
+Finally, access the application from your web browser. Visit
+[http://localhost:8080](http://localhost:8080).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,11 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "pykern",
+    'lcls-tools @ git+https://github.com/slaclab/lcls-tools',
+    'pyepics',
+    'pykern @ git+https://github.com/radiasoft/pykern',
+    'scikit-learn==1.3.2' ,
+    'scipy',
 ]
 description = "SlicOps: Library and UI for beam physics control systems"
 dynamic = ["version"]


### PR DESCRIPTION
From within the project root run `curl radia.run | container-build`. When the process finishes an OCI compliant image will be created.