### PR TITLE
Fix #54 service.ui_api add --prod and --tcp-port

### DIFF
--- a/slicops/package_data/.gitignore
+++ b/slicops/package_data/.gitignore
@@ -1,0 +1,1 @@
+ng-build/


### PR DESCRIPTION
- prod flag adds pkresource ng-build as static file directory
- tcp-port allows port to be easily specified (vs config)
- gitignore of package_data/ng-build